### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Buildkite plugin for running Snyk scans
 steps:
   - name: "Snyk testing"
     plugins:
-      seek-oss/aws-sm#v0.0.5:
-        env:
-          SNYK_TOKEN: snyk-service-user-api-key
-      seek-oss/snyk#v0.0.4:
-        block: true
-        language: node
-        path: package.json
-        severity: low
-        npmToken: NPM_TOKEN
+      - seek-oss/aws-sm#v0.0.5:
+          env:
+            SNYK_TOKEN: snyk-service-user-api-key
+      - seek-oss/snyk#v0.0.4:
+          block: true
+          language: node
+          path: package.json
+          severity: low
+          npmToken: NPM_TOKEN
     agents: 
       queue: "security-prod:cicd"
 ```


### PR DESCRIPTION
Hi @2rtan! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.