### PR TITLE
Updated base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.0-alpine3.8
+FROM python:3.7.4-alpine3.10
 RUN apk update && apk add --update npm jq go libc-dev openjdk8
 RUN apk add --no-cache nss
 RUN npm config set unsafe-perm true


### PR DESCRIPTION
The previous base image used Alpine 3.8 which pulls Go 1.10. Snyk assumes a newer
version of Go, as it passes flags, such as `-dep` to `go` which aren't available in go
1.10

Alpine 3.10 pulls Go 1.12 which is compatible with Snyk