### PR TITLE
Update Dockerfile to not use piccolo.link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm config set unsafe-perm true
 RUN npm install -g snyk
 RUN pip install boto3
 RUN apk add --no-cache --virtual=build-dependencies curl wget tar && \
-  curl -sL "https://piccolo.link/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
+  curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
       ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
       chmod 0755 /usr/local/bin/sbt && \
       mkdir -p /tmp/sbt-preload && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm config set unsafe-perm true
 RUN npm install -g snyk
 RUN pip install boto3
 RUN apk add --no-cache --virtual=build-dependencies curl wget tar && \
-  curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
+  curl -fsL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
       ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
       chmod 0755 /usr/local/bin/sbt && \
       mkdir -p /tmp/sbt-preload && \


### PR DESCRIPTION
Piccolo.link seems to go down from time to time.
According to https://github.com/sbt/sbt/issues/5860#issuecomment-698212882
It is more stable to replace the link with `https://github.com/sbt/sbt/releases/download/v<SBT_VERSION>/sbt-<SBT_VERSION>.tgz`